### PR TITLE
Added redirect feature

### DIFF
--- a/lib/response.mjs
+++ b/lib/response.mjs
@@ -18,5 +18,11 @@ export default {
       this.setHeader('Content-Length', json.length)
       this.write(json)
     }
+  },
+
+  redirect (url) {
+    this.statusCode = 308
+    this.setHeader('Location', url)
+    this.send('redirected permanently')
   }
 }


### PR DESCRIPTION
Added a redirect function to `Response` object which takes in the relative `url` to be redirected to. Sets the `statusCode` to `308` as per turbo-http documentation `set(308, 'Permanent Redirect')`